### PR TITLE
Microsoft License Headers and Re-release under Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,13 @@
-The MIT License (MIT)
+Copyright 2016 Microsoft Corporation
 
-Copyright (c) 2015 Microsoft
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+    http://www.apache.org/licenses/LICENSE-2.0
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/main/java/com/hazelcast/azure/AzureAuthHelper.java
+++ b/src/main/java/com/hazelcast/azure/AzureAuthHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, Microsoft. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.azure;
 
 import com.microsoft.aad.adal4j.AuthenticationContext;

--- a/src/main/java/com/hazelcast/azure/AzureDiscoveryStrategy.java
+++ b/src/main/java/com/hazelcast/azure/AzureDiscoveryStrategy.java
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/*
+ * Additional Modifications by Microsoft Corporation
+ */
 package com.hazelcast.azure;
 
 import com.hazelcast.config.InvalidConfigurationException;

--- a/src/main/java/com/hazelcast/azure/AzureDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/azure/AzureDiscoveryStrategyFactory.java
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/*
+ * Additional Modifications by Microsoft Corporation
+ */
 package com.hazelcast.azure;
 
 import com.hazelcast.config.properties.PropertyDefinition;

--- a/src/main/java/com/hazelcast/azure/AzureProperties.java
+++ b/src/main/java/com/hazelcast/azure/AzureProperties.java
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Additional Modifications by Microsoft Corporation
+ */
 
 package com.hazelcast.azure;
 

--- a/src/test/java/com/hazelcast/azure/AzureDiscoveryStrategyFactoryTest.java
+++ b/src/test/java/com/hazelcast/azure/AzureDiscoveryStrategyFactoryTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2016, Microsoft. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hazelcast.azure.test;
 
 import com.hazelcast.azure.AzureProperties;

--- a/src/test/java/com/hazelcast/azure/AzureDiscoveryStrategyTest.java
+++ b/src/test/java/com/hazelcast/azure/AzureDiscoveryStrategyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2016, Microsoft. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hazelcast.azure.test;
 
 import com.hazelcast.azure.AzureDiscoveryStrategy;

--- a/src/test/java/com/hazelcast/azure/AzurePropertiesTest.java
+++ b/src/test/java/com/hazelcast/azure/AzurePropertiesTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2016, Microsoft. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hazelcast.azure.test;
 
 import com.hazelcast.azure.AzureProperties;

--- a/src/test/java/com/hazelcast/azure/integration/LiveTest.java
+++ b/src/test/java/com/hazelcast/azure/integration/LiveTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, Microsoft. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.azure.test.integration;
 
 import com.hazelcast.azure.AzureAuthHelper;


### PR DESCRIPTION
'Additional Modifications by Microsoft Corporation'
These are original files from Hazelcast modified by Microsoft

New Apache Microsoft headers for original Microsoft code files
